### PR TITLE
fix: tailwind does not support sass in vite plugin

### DIFF
--- a/packages/projects/src/main.ts
+++ b/packages/projects/src/main.ts
@@ -4,6 +4,7 @@ import App from './App.vue'
 import NotFoundComponent from './components/NotFound.vue'
 import HomeView from './views/home/Home.vue'
 import YuQueView from './views/yuque/YuQue.vue'
+import 'tailwindcss/index.css'
 import './style.scss'
 
 const routes = [

--- a/packages/projects/src/style.scss
+++ b/packages/projects/src/style.scss
@@ -1,4 +1,3 @@
-@import 'tailwindcss';
 @import '@opentiny/fluent-editor/style.scss';
 @import 'quill-header-list/dist/index.css';
 @import 'quill-table-up/index.css';


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

tailwindcss4 no longer support import in sass with vite plugin. https://github.com/tailwindlabs/tailwindcss/discussions/16793#discussioncomment-12311565

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The application now fully leverages Tailwind CSS, enabling enhanced aesthetic appeal through responsive and modern styling improvements for a better user experience. Users will benefit from a cleaner, more adaptable interface.

- **Chores**
  - The styling configuration has been refined by removing redundant import statements, resulting in a more efficient, maintainable, and consistent integration across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->