### PR TITLE
fix(i18n): toolbar header picker 切换语言后 label 显示不正确

### DIFF
--- a/packages/fluent-editor/src/modules/toolbar/better-toolbar.ts
+++ b/packages/fluent-editor/src/modules/toolbar/better-toolbar.ts
@@ -43,7 +43,7 @@ export class BetterToolbar extends Toolbar {
           option = select.querySelector('option[selected]')
         }
         else if (!Array.isArray(formats[format])) {
-          let value = format === 'header' ? formats[format].value : formats[format]
+          let value = formats[format]
           if (typeof value === 'string') {
             value = value.replace(/"/g, '\\"')
           }

--- a/packages/fluent-editor/src/themes/snow.ts
+++ b/packages/fluent-editor/src/themes/snow.ts
@@ -195,17 +195,16 @@ class SnowTheme extends OriginSnowTheme {
       }
 
       if (picker.select && picker.select.classList.contains('ql-header')) {
-        const select = picker.select as HTMLSelectElement
+        const getLabelKey = (v: string | null) => (v ? `h${v}` : 'normal')
 
+        // 更新 label 文本
+        const labelValue = picker.label.getAttribute('data-value')
+        picker.label.setAttribute('data-label', this.quill.getLangText(getLabelKey(labelValue)))
+
+        const select = picker.select as HTMLSelectElement
         Array.from(select.options).forEach((option) => {
           const value = option.getAttribute('value')
-          const trText = this.quill.getLangText(value ? `h${value}` : 'normal')
-
-          if (option.getAttribute('selected')) {
-            picker.label.setAttribute('data-label', trText)
-          }
-
-          option.textContent = trText
+          option.textContent = this.quill.getLangText(getLabelKey(value))
         })
 
         picker.options.remove()

--- a/packages/fluent-editor/src/themes/snow.ts
+++ b/packages/fluent-editor/src/themes/snow.ts
@@ -195,7 +195,7 @@ class SnowTheme extends OriginSnowTheme {
       }
 
       if (picker.select && picker.select.classList.contains('ql-header')) {
-        const getLabelKey = (v: string | null) => (v ? `h${v}` : 'normal')
+        const getLabelKey = (v: string | null) => (v ? `header-${v}` : 'header-normal')
 
         // 更新 label 文本
         const labelValue = picker.label.getAttribute('data-value')
@@ -221,6 +221,7 @@ class SnowTheme extends OriginSnowTheme {
         }
         return new IconPicker(select, icons.align as Record<string, string>)
       }
+
       if (select.classList.contains('ql-background') || select.classList.contains('ql-color')) {
         const format = select.classList.contains('ql-background') ? 'background' : 'color'
         if (isNullOrUndefined(select.querySelector('option'))) {
@@ -231,6 +232,7 @@ class SnowTheme extends OriginSnowTheme {
           closeAfterChange: false,
         })
       }
+
       if (isNullOrUndefined(select.querySelector('option'))) {
         if (select.classList.contains('ql-font')) {
           fillSelect(select, FONTS)
@@ -247,6 +249,7 @@ class SnowTheme extends OriginSnowTheme {
       }
       return new Picker(select)
     })
+
     const update = () => {
       this.pickers.forEach((picker) => {
         if (picker instanceof ColorPicker) return
@@ -277,6 +280,7 @@ function fillSelect(select, values, defaultValue = false) {
     select.appendChild(option)
   })
 }
+
 function fillColorSelect(
   select: HTMLSelectElement,
   values: Array<string | boolean>,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
修复

1. header 从 Text （false） 选项切换到其他选项后 需要切换两次 picker label 才会正常显示
2. 切换语言后，选项选中状态会重置

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
