### PR TITLE
feat: output continuous spaces as &nbsp

### DIFF
--- a/packages/fluent-editor/src/config/editor.utils.ts
+++ b/packages/fluent-editor/src/config/editor.utils.ts
@@ -105,6 +105,49 @@ export function replaceDeltaImage(delta, imageUrls, imagePlaceholder) {
   }, new Delta())
 }
 
+const WHITE_SPACE_CHAR_RE = /^[\u3000\u0020]$/
+const WHITE_SPACE_OR_NBSP_RE = /^[\u3000\u0020\u00A0]$/
+
+/**
+ * 将连续空格转为不间断空格，以便 innerHTML 输出 &nbsp; 并在预览中保留间距。
+ * - 行首空白：全部转为 \u00A0
+ * - 正文内连续空白：保留第一个普通空格，其余转为 \u00A0
+ */
+export function replaceStrWhiteSpace(str: string) {
+  let textWithWhiteSpace = ''
+  let beginHasChar = false
+  let consecutiveSpaces = 0
+  for (const char of str) {
+    if (WHITE_SPACE_CHAR_RE.test(char)) {
+      consecutiveSpaces += 1
+      if (!beginHasChar) {
+        textWithWhiteSpace += '\u00A0'
+      }
+      else if (consecutiveSpaces === 1) {
+        textWithWhiteSpace += char
+      }
+      else {
+        textWithWhiteSpace += '\u00A0'
+      }
+    }
+    else {
+      consecutiveSpaces = 0
+      textWithWhiteSpace += char
+      beginHasChar = true
+    }
+  }
+  return textWithWhiteSpace
+}
+
+/** 空格键是否应插入不间断空格（与 replaceStrWhiteSpace 规则一致） */
+export function shouldInsertNbspOnSpace(prefix: string) {
+  if (!prefix) {
+    return true
+  }
+  const lastChar = prefix.slice(-1)
+  return WHITE_SPACE_OR_NBSP_RE.test(lastChar)
+}
+
 export function splitWithBreak(insertContent: string) {
   const lines = []
   const insertStr = insertContent

--- a/packages/fluent-editor/src/modules/custom-clipboard.ts
+++ b/packages/fluent-editor/src/modules/custom-clipboard.ts
@@ -12,6 +12,7 @@ import {
   isNullOrUndefined,
   omit,
   replaceDeltaImage,
+  replaceStrWhiteSpace,
   splitWithBreak,
 } from '../config/editor.utils'
 import { isString } from '../utils/is'
@@ -452,22 +453,6 @@ function rebuildDelta(delta, cellLine) {
   }, new Delta())
 
   return buildedDelta
-}
-
-function replaceStrWhiteSpace(str) {
-  const isWhiteSpace = value => /^(\u3000|\u0020){1}$/.test(value) // 空白字符
-  let textWithWhiteSpace = ''
-  let beginHasChar = false
-  for (const char of str) {
-    if (isWhiteSpace(char) && !beginHasChar) {
-      textWithWhiteSpace += '\u00A0'
-    }
-    else {
-      textWithWhiteSpace += char
-      beginHasChar = true
-    }
-  }
-  return textWithWhiteSpace
 }
 
 function replaceDeltaWhiteSpace(delta, rootBgColor?) {

--- a/packages/fluent-editor/src/themes/snow.ts
+++ b/packages/fluent-editor/src/themes/snow.ts
@@ -2,7 +2,7 @@ import type { ThemeOptions } from 'quill/core/theme'
 import type TypeToolbar from 'quill/modules/toolbar'
 import type TypeIconPicker from 'quill/ui/icon-picker'
 import { I18N_LOCALE_CHANGE } from 'quill-i18n'
-import { inputFile, isNullOrUndefined } from '../config'
+import { inputFile, isNullOrUndefined, shouldInsertNbspOnSpace } from '../config'
 import FluentEditor from '../core/fluent-editor'
 import { CustomImageSpec } from '../modules/custom-image/specs/custom-image-spec'
 import { LinkTooltip } from '../modules/link'
@@ -21,6 +21,23 @@ OriginSnowTheme.DEFAULTS = {
     'keyboard': {
       bindings: {
         ...shortKey,
+        preserveWhiteSpace: {
+          key: ' ',
+          collapsed: true,
+          handler(this: { quill: FluentEditor }, range, context) {
+            if (!shouldInsertNbspOnSpace(context.prefix)) {
+              return true
+            }
+            this.quill.insertText(
+              range.index,
+              '\u00A0',
+              context.format,
+              FluentEditor.sources.USER,
+            )
+            this.quill.setSelection(range.index + 1, FluentEditor.sources.SILENT)
+            return false
+          },
+        },
       },
     },
     'toolbar': {


### PR DESCRIPTION
将连续空格转为不间断空格，以便 innerHTML 输出 &nbsp; 并在预览中保留间距
修改前：
<img width="714" height="419" alt="空格2" src="https://github.com/user-attachments/assets/c5125317-3c51-4ec5-918b-3c53a749c95b" />

修改后：
<img width="696" height="439" alt="空格1" src="https://github.com/user-attachments/assets/4fac58c1-f60f-4d54-a0d1-894b9d9f5d74" />

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced whitespace handling in the editor with context-aware automatic conversion of spaces to non-breaking spaces for improved HTML formatting consistency.
  * Better spacing preservation during typing to ensure consistent formatting output across various content scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-editor/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->