### PR TITLE
fix: fix the issue of failed title switching after using the quill-header-list plugin

### DIFF
--- a/packages/docs/fluent-editor/demos/header-list-container.vue
+++ b/packages/docs/fluent-editor/demos/header-list-container.vue
@@ -26,6 +26,9 @@ onMounted(async () => {
           [{ header: [null, 1, 2, 3, 4, 5, 6] }, 'header-list'],
         ],
         handlers: {
+          header(value: string | false) {
+            this.quill.format('header', value === false ? false : Number(value))
+          },
           'header-list': HeaderList.toolbarHandle,
         },
       },

--- a/packages/docs/fluent-editor/demos/header-list-container.vue
+++ b/packages/docs/fluent-editor/demos/header-list-container.vue
@@ -8,14 +8,18 @@ const editorRef = ref<HTMLElement>()
 const headerListRef = ref<HTMLElement>()
 
 onMounted(async () => {
-  // ssr compat, reference: https://vitepress.dev/guide/ssr-compat#importing-in-mounted-hook
-  const [{ default: FluentEditor, DEFAULT_TOOLBAR }, { default: HeaderList }] = await Promise.all([
+  const [
+    { default: FluentEditor, DEFAULT_TOOLBAR },
+    { default: HeaderList, HeaderWithID },
+  ] = await Promise.all([
     import('@opentiny/fluent-editor'),
     import('quill-header-list'),
   ])
 
   if (!editorRef.value) return
   FluentEditor.register({ 'modules/header-list': HeaderList }, true)
+
+  HeaderWithID.idKey = 'id'
 
   editor = new FluentEditor(editorRef.value, {
     theme: 'snow',

--- a/packages/docs/fluent-editor/demos/header-list.vue
+++ b/packages/docs/fluent-editor/demos/header-list.vue
@@ -26,6 +26,9 @@ onMounted(async () => {
           [{ header: [false, 1, 2, 3, 4, 5, 6] }, 'header-list'],
         ],
         handlers: {
+          header(value: string | false) {
+            this.quill.format('header', value === false ? false : Number(value))
+          },
           'header-list': HeaderList.toolbarHandle,
         },
       },

--- a/packages/docs/fluent-editor/demos/header-list.vue
+++ b/packages/docs/fluent-editor/demos/header-list.vue
@@ -9,13 +9,18 @@ const headerListRef = ref<HTMLElement>()
 
 onMounted(async () => {
   // ssr compat, reference: https://vitepress.dev/guide/ssr-compat#importing-in-mounted-hook
-  const [{ default: FluentEditor, DEFAULT_TOOLBAR }, { default: HeaderList }] = await Promise.all([
+  const [
+    { default: FluentEditor, DEFAULT_TOOLBAR },
+    { default: HeaderList, HeaderWithID },
+  ] = await Promise.all([
     import('@opentiny/fluent-editor'),
     import('quill-header-list'),
   ])
 
   if (!editorRef.value) return
   FluentEditor.register({ 'modules/header-list': HeaderList }, true)
+
+  HeaderWithID.idKey = 'id'
 
   editor = new FluentEditor(editorRef.value, {
     theme: 'snow',


### PR DESCRIPTION
解决用了quill-header-list插件后切换标题失败的问题

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header formatting controls in the editor demos.
  * Header levels are now applied correctly, with formatting reliably removed when the unformatted option is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->